### PR TITLE
fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 SchemeLESS
-=========
+===
 
-Schemeless is a color scheme file for LESS which enables you to easily generate color schemes and customize them as much or as little as you want.
+SchemeLESS is a color scheme file for [LESS](http://lesscss.org/) that enables you to easily generate color schemes and customize them as much or as little as you want.
 
-Version
--
+<dl>
+  <dt>Version</dt>
+  <dd>1.0</dd>
+</dl>
 
-1.0
 
 How to use it
------------
+---
 
-Edit or overwrite the @seed-color value to generate a scheme based on that color.
+Edit or overwrite the `@seed-color` value to generate a scheme based on that color.
 
-SchemeLESS works best when it's imported and compiled alongside other LESS files that reference it. In a pinch, just paste it in.
+SchemeLESS works best when it’s imported and compiled alongside other LESS files that reference it. In a pinch, just paste it in.
 
-Example index.less
---------------
 
-```@import "scheme.less"; // color scheme
-@import "style.less"; // your own styles
-```
-    
+Example `index.less`
+---
+
+    @import "scheme.less"; // color scheme
+    @import "style.less"; // your own styles


### PR DESCRIPTION
detailed list of changes:
- fix code formatting of `index.less` – GitHub-Flavored Markdown is not supported in repository files
- add inline code formatting
- change the “Version”: “1.0” section to a prettier and more-semantic `<dl>` definition list
- since all headings have the wrong number of underlines, just change to three underlines, so they don’t need to be maintained in the future
- fix grammar, capitalization, and typography
- make “LESS” a link in case someone stumbles on this project without knowing what it is
- add blank lines between sections to make them more visually distinguishable
